### PR TITLE
Add trim function on compared string to avoid false result with space…

### DIFF
--- a/src/Knp/FriendlyContexts/Utils/Asserter.php
+++ b/src/Knp/FriendlyContexts/Utils/Asserter.php
@@ -58,7 +58,7 @@ class Asserter
                 do {
                     $content = array_shift($columns);
                     $result = $columnElement
-                        ? $content === $columnElement->getContent()
+                        ? $content === trim($columnElement->getContent())
                         : false
                     ;
                     $columnElement = $columnElement ? $columnElement->getRight() : null;


### PR DESCRIPTION
… at the end and begining of the string